### PR TITLE
make write_many nestable via SAVEPOINT instead of BEGIN/COMMIT

### DIFF
--- a/src/sqlite3.erl
+++ b/src/sqlite3.erl
@@ -828,9 +828,9 @@ handle_call({write, Tbl, Data}, _From, State) ->
             {reply, {error, Exception}, State}
     end;
 handle_call({write_many, Tbl, DataList}, _From, State) ->
-    SQLScript = ["BEGIN;", 
+    SQLScript = ["SAVEPOINT 'erlang-sqlite3-write_many';", 
                  [sqlite3_lib:write_sql(Tbl, Data) || Data <- DataList], 
-                 "COMMIT;"],
+                 "RELEASE SAVEPOINT 'erlang-sqlite3-write_many';"],
     Reply = do_sql_exec_script(SQLScript, State),
     {reply, Reply, State};
 handle_call({read, Tbl}, _From, State) ->


### PR DESCRIPTION
unfortunately BEGIN...COMMIT isn't nestable in sqlite3, but SAVEPOINTS are:
http://www.sqlite.org/lang_savepoint.html

ran into this using write_many while already inside BEGIN...COMMIT. I could rewrite my app but it's simpler to make this lib nestable.
