### PR TITLE
fixed test file path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Note that on Windows, `sqlite3.dll` usually won't be installed in the system-wid
 
 ## Example usage
 
-See tests `src/sqlite3_test.erl` for a starting point.
+See tests `test/sqlite3_test.erl` for a starting point.
 
 ## Authors
 


### PR DESCRIPTION
fa377cc9422e78570376347a94cc1147807c51e3 moved the test file from `src` to `test`, while README still mentioned former
