### PR TITLE
Fix OS X compilation

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,9 @@
 % -*- mode: erlang -*-
-{port_env, [{"^(?!.*win32)", "DRV_CFLAGS", "$DRV_CFLAGS -Wall -Wextra -Wno-unused-parameter -Wstrict-prototypes"},
-             {"^(?!.*win32)", "DRV_LDFLAGS", "$DRV_LDFLAGS -lsqlite3"},
-             {".*win32.*", "DRV_CFLAGS", "$DRV_CFLAGS /O2 /Isqlite3_amalgamation /Ic_src /W4 /wd4100 /wd4204 /wd4820 /wd4255 /wd4668 /wd4710 /wd4711"},
-             {".*win32.*", "DRV_LDFLAGS", "$DRV_LDFLAGS sqlite3.lib"}]}.
+{port_env, [{"DRV_CFLAGS", "$DRV_CFLAGS -Wall -Wextra -Wno-unused-parameter -Wstrict-prototypes"},
+            {"DRV_LDFLAGS", "$DRV_LDFLAGS -lsqlite3"},
+            {"darwin", "DRV_CFLAGS", "$DRV_CFLAGS -Wall -Wextra -Wno-unused-parameter -Wstrict-prototypes"},
+            {"darwin", "DRV_LDFLAGS", "$DRV_LDFLAGS -L$(brew --prefix sqlite)/lib -lsqlite3"},
+            {".*win32.*", "DRV_CFLAGS", "$DRV_CFLAGS /O2 /Isqlite3_amalgamation /Ic_src /W4 /wd4100 /wd4204 /wd4820 /wd4255 /wd4668 /wd4710 /wd4711"},
+            {".*win32.*", "DRV_LDFLAGS", "$DRV_LDFLAGS sqlite3.lib"}]}.
 {cover_enabled, true}.
 {eunit_opts, [verbose, {report,{eunit_surefire,[{dir,"."}]}}]}.


### PR DESCRIPTION
I'm not sure if there is any interest in this change, but I wanted to put it out there. Currently building on OS X fails because of the old version of SQLite it ships with. The build works for OS X with this change if and only if the latest version of SQLite is installed with `brew`.

This causes the port driver to use the `brew` version of SQLite on OS X (darwin). This version is more up-to-date an includes functionality like loading extensions.