### PR TITLE
Remove unused variable

### DIFF
--- a/test/sqlite3_test.erl
+++ b/test/sqlite3_test.erl
@@ -138,7 +138,6 @@ table_info() ->
                id INTEGER PRIMARY KEY,
                ts TEXT default (timestamp('now')),
                key TEXT);">>,
-    ExpectedTableInfo =
     sqlite3:sql_exec(ct,Sql),
     ?assertMatch(
         [{id, integer, [primary_key]},


### PR DESCRIPTION
Remove unused variable `ExpectedTableInfo` in `test/sqlite3_test.erl`.