### PR TITLE
Fix emergency_close warning

### DIFF
--- a/c_src/sqlite3_drv.c
+++ b/c_src/sqlite3_drv.c
@@ -210,6 +210,9 @@ static ErlDrvEntry sqlite3_driver_entry = {
   NULL /* handle2 */,
   NULL /* process_exit */,
   NULL /* stop_select */
+  #if ERL_DRV_EXTENDED_MAJOR_VERSION >= 3 && ERL_DRV_EXTENDED_MINOR_VERSION >=2
+  NULL /* emergency_close */,
+  #endif
 };
 
 DRIVER_INIT(sqlite3_driver) {


### PR DESCRIPTION
`ErlDrvEntry` got a new field, `emergency_close`, in 17.4. This corresponds
to `ERL_DRV_EXTENDED_MAJOR_VERSION=3` and `ERL_DRV_EXTENDED_MINOR_VERSION=2`.
This patch adds a check to see if the version is >= 3.2 and adds an
initialized for `emergency_close` if it's needed. This gets rid of an annoying
warning (missing initializer) for recent Erlang versions.