### PR TITLE
Add 17.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: erlang
 script: "make test"
 otp_release:
+  - 18.0
+  - 17.4
   - 17.3
   - R16B03-1
   - R15B03

--- a/c_src/sqlite3_drv.c
+++ b/c_src/sqlite3_drv.c
@@ -209,7 +209,13 @@ static ErlDrvEntry sqlite3_driver_entry = {
   ERL_DRV_FLAG_USE_PORT_LOCKING, /* ERL_DRV_FLAGs */
   NULL /* handle2 */,
   NULL /* process_exit */,
+  #if ERL_DRV_EXTENDED_MAJOR_VERSION > 3 || \
+  (ERL_DRV_EXTENDED_MAJOR_VERSION == 3 && ERL_DRV_EXTENDED_MINOR_VERSION >= 2)
+  NULL /* stop_select */,
+  NULL /* emergency_close */
+  #else
   NULL /* stop_select */
+  #endif
 };
 
 DRIVER_INIT(sqlite3_driver) {


### PR DESCRIPTION
Erlang 17.4 added a new driver entry, `emergency_close`. This
patch tests for it by driver versions and adds an initializer if
necessary. This patch also adds new Erlang versions to the Travis CI config
to test the new driver field.