### PR TITLE
Fix OS X

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,10 @@
 % -*- mode: erlang -*-
+{port_specs, [{"priv/sqlite3_drv.so", ["c_src/*.c"]},
+              {"darwin", "priv/sqlite3_drv.so", ["c_src/*.c", "sqlite3_amalgamation/*.c"]}]}.
 {port_env, [{"DRV_CFLAGS", "$DRV_CFLAGS -Wall -Wextra -Wno-unused-parameter -Wstrict-prototypes"},
             {"DRV_LDFLAGS", "$DRV_LDFLAGS -lsqlite3"},
             {"darwin", "DRV_CFLAGS", "$DRV_CFLAGS -Wall -Wextra -Wno-unused-parameter -Wstrict-prototypes"},
-            {"darwin", "DRV_LDFLAGS", "$DRV_LDFLAGS -L$(brew --prefix sqlite)/lib -lsqlite3"},
+            {"darwin", "DRV_LDFLAGS", "$DRV_LDFLAGS"},
             {".*win32.*", "DRV_CFLAGS", "$DRV_CFLAGS /O2 /Isqlite3_amalgamation /Ic_src /W4 /wd4100 /wd4204 /wd4820 /wd4255 /wd4668 /wd4710 /wd4711"},
             {".*win32.*", "DRV_LDFLAGS", "$DRV_LDFLAGS sqlite3.lib"}]}.
 {cover_enabled, true}.


### PR DESCRIPTION
This is my second/better attempt at fixing the OS X build. This build
explicitly includes the sqlite3 amalgamation files. sqlite shipped on
OS X is old. It doesn't support extensions. This change allows users to
build erlang-sqlite3 on OS X and pass tests.