### PR TITLE
Fixed compile warning

### DIFF
--- a/c_src/sqlite3_drv.c
+++ b/c_src/sqlite3_drv.c
@@ -456,7 +456,7 @@ static inline void exec_async_command(
 
     // see https://groups.google.com/d/msg/erlang-programming/XiFR6xxhGos/B6ARBIlvpMUJ
     if (status < 0) {
-      LOG_ERROR("driver_async call failed", 0);
+      LOG_ERROR("driver_async call failed: %ld", status);
       output_error(drv, SQLITE_ERROR, "driver_async call failed");
     }
   } else {


### PR DESCRIPTION
When you compile project it returns following warning:

> c_src/sqlite3_drv.c: In function ‘exec_async_command’:
> c_src/sqlite3_drv.c:459:7: warning: too many arguments for format
> [-Wformat-extra-args]
>          LOG_ERROR("driver_async call failed", 0);

This patch fixes mentioned warning.
